### PR TITLE
Document training steps and fix app file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
 This repository demonstrates how deep learning can be applied to anomaly detection.
 The method used is an autoencoder neural network.
 The training dataset was obtained from Kaggle and contains 1000 rows and 11 columns.
+
+## Training the model
+
+Two files are required for the Streamlit app to run:
+
+* `autoencoder_keras.h5` – the trained autoencoder model
+* `preprocessor.joblib` – the fitted `ColumnTransformer` used for preprocessing
+
+These files are not stored in the repository. To generate them yourself:
+
+1. Install the dependencies
+
+   ```bash
+   pip install -r model/requirements.txt
+   ```
+
+2. Ensure your Kaggle API credentials are configured so that `kagglehub` can download the training dataset.
+   Follow the [Kaggle API instructions](https://github.com/Kaggle/kaggle-api#api-credentials) to create the `~/.kaggle/kaggle.json` file.
+
+3. From the repository root, run the training script
+
+   ```bash
+   python model/train.py
+   ```
+
+   This will download the dataset, train the autoencoder and save `autoencoder_keras.h5`
+   and `preprocessor.joblib` in the repository root.
+
+## Running the application
+
+After training, start the Streamlit app with
+
+```bash
+streamlit run app.py
+```
+
+The application looks for `autoencoder_keras.h5` and `preprocessor.joblib` in the
+same directory as `app.py` and will fail to start if they are missing.

--- a/app.py
+++ b/app.py
@@ -3,11 +3,17 @@ import pandas as pd
 import numpy as np
 import joblib
 import tensorflow as tf
+from pathlib import Path
 from model import build_autoencoder
 
+# Resolve paths relative to this file so the app works when deployed
+BASE_DIR = Path(__file__).resolve().parent
+MODEL_PATH = BASE_DIR / "autoencoder_keras.h5"
+PREPROCESSOR_PATH = BASE_DIR / "preprocessor.joblib"
+
 # Load model & preprocessor
-model = tf.keras.models.load_model("autoencoder_keras.h5")
-preprocessor = joblib.load("preprocessor.joblib")
+model = tf.keras.models.load_model(MODEL_PATH)
+preprocessor = joblib.load(PREPROCESSOR_PATH)
 threshold = 0.5888  # Adjust based on training results
 
 st.title("Pipeline Anomaly Detection")


### PR DESCRIPTION
## Summary
- document how to train the autoencoder and generate required files
- load model and preprocessor using paths relative to `app.py`

## Testing
- `python -m py_compile app.py model/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c6ce70cb4832ea5254461c28cc79d