### PR TITLE
Fix autoencoder import

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ import numpy as np
 import joblib
 import tensorflow as tf
 from pathlib import Path
-from model import build_autoencoder
 
 # Resolve paths relative to this file so the app works when deployed
 BASE_DIR = Path(__file__).resolve().parent

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,0 +1,1 @@
+from .model import build_autoencoder


### PR DESCRIPTION
## Summary
- expose `build_autoencoder` from `model` package
- remove unused import from `app.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c6d6706f0832e89b8fceac3e73d92